### PR TITLE
Bugfixing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -301,8 +301,15 @@ export function parseFromAST(data:IParseNode):IParsedTypeCollection {
  * @param data
  * @returns {any}
  */
-export function parseTypeFromAST(name:string,data:IParseNode,collection:IParsedTypeCollection,defaultsToAny:boolean=false,annotation:boolean=false,global:boolean=true):IParsedType {
-    return tc.parse(name,<any>data,collection? <ts.TypeRegistry>collection.getTypeRegistry():ts.builtInRegistry(),defaultsToAny,annotation,global);
+export function parseTypeFromAST(
+    name:string,
+    data:IParseNode,
+    collection:IParsedTypeCollection,
+    defaultsToAny:boolean=false,
+    annotation:boolean=false,
+    global:boolean=true,
+    ignoreTypeAttr:boolean=false):IParsedType {
+    return tc.parse(name,<any>data,collection? <ts.TypeRegistry>collection.getTypeRegistry():ts.builtInRegistry(),defaultsToAny,annotation,global,ignoreTypeAttr);
 }
 /**
  * dumps type or type collection to JSON

--- a/src/nominals.ts
+++ b/src/nominals.ts
@@ -1,7 +1,7 @@
 import ts=require("./typesystem")
 import nt=require("./nominal-types")
 import parse=require("./parse")
-import {ComponentShouldBeOfType} from "./restrictions";
+import restrictions = require("./restrictions");
 import {FacetDeclaration} from "./metainfo";
 import {Description} from "./metainfo";
 import {DisplayName} from "./metainfo";
@@ -67,7 +67,7 @@ export function toNominal(t:ts.AbstractType,callback:StringToBuiltIn,customizer:
             var ar = new nt.Array(t.name(), null);
             vs = ar;
             t.putExtra(NOMINAL, vs);
-            var cm = t.oneMeta(ComponentShouldBeOfType);
+            var cm = t.oneMeta(restrictions.ComponentShouldBeOfType);
             var r = cm ? cm.value() : ts.ANY;
             ar.setComponent(toNominal(r, callback));
         }
@@ -150,7 +150,13 @@ export function toNominal(t:ts.AbstractType,callback:StringToBuiltIn,customizer:
     })
     t.customFacets().forEach(x=>{
         vs.fixFacet(x.facetName(), x.value());
-    })
+    });
+    var basicFacets = <restrictions.FacetRestriction<any>[]>
+            t.metaOfType(<any>restrictions.FacetRestriction);
+
+    for(var x of basicFacets){
+        vs.fixFacet(x.facetName(), x.value());
+    }
     vs.addAdapter(t);
     if (t.isEmpty()){
         vs.addAdapter(new nt.Empty());

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -619,7 +619,14 @@ function typeToSignature(t:ts.AbstractType):string{
  * @param r
  * @returns {any}
  */
-export function parse(name: string,n:ParseNode,r:ts.TypeRegistry=ts.builtInRegistry(),defaultsToAny:boolean=false,annotation:boolean=false,global:boolean=true):ts.AbstractType{
+export function parse(
+    name: string,
+    n:ParseNode,
+    r:ts.TypeRegistry=ts.builtInRegistry(),
+    defaultsToAny:boolean=false,
+    annotation:boolean=false,
+    global:boolean=true,
+    ignoreTypeAttr:boolean=false):ts.AbstractType{
     //Build super types.
 
     var provider: su.IContentProvider = (<any>n).contentProvider ? (<any>n).contentProvider() : null;
@@ -661,7 +668,7 @@ export function parse(name: string,n:ParseNode,r:ts.TypeRegistry=ts.builtInRegis
             shAndType=true;
         }
     }
-    if (!tp){
+    if (!tp||ignoreTypeAttr){
         if (defaultsToAny){
             if (n.childWithKey("properties")) {
                 superTypes = [ts.OBJECT];


### PR DESCRIPTION
Bugs fixed:
https://github.com/raml-org/raml-js-parser-2/issues/268
https://github.com/raml-org/raml-js-parser-2/issues/288

Features introduced
* build-in facets values are passed to nominal type
* ability to parse type ignoring value of "type" attribute. Important for types with parametrized value of "type" attribute.