### PR TITLE
Implementing detailed error messages for facet conflicts and min-max facets.

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -115,14 +115,22 @@ export class PropertyBean{
         if (!this.optional&&!this.additonal&&!this.regExp){
             t.addMeta(new rs.HasProperty(this.id));
         }
+        var matchesPropertyFacet:rs.MatchesProperty;
         if (this.additonal){
-            t.addMeta(new rs.AdditionalPropertyIs(this.type));
+            matchesPropertyFacet = new rs.AdditionalPropertyIs(this.type);
         }
         else if (this.regExp){
-            t.addMeta(new rs.MapPropertyIs(this.id,this.type));
+            matchesPropertyFacet = new rs.MapPropertyIs(this.id,this.type);
         }
         else{
-            t.addMeta(new rs.PropertyIs(this.id,this.type,this.optional));
+            matchesPropertyFacet = new rs.PropertyIs(this.id,this.type,this.optional);            
+        }
+        if(matchesPropertyFacet!=null){
+            t.addMeta(matchesPropertyFacet);
+            if(this.type instanceof ts.InheritedType && this.type.name()==null){
+                //Linking anonymous types with properties declaring them
+                (<ts.InheritedType>this.type).setContextMeta(matchesPropertyFacet);
+            }
         }
     }
 }


### PR DESCRIPTION
Conflicts examples:
```
types:
  Number1:
    type: number
    maximum: 2
  Number2:
    type: number
    minimum: 4
  Number3: [ Number1, Number2 ] #Restrictions conflict in type 'Number3': ['Number2.minimum=4' is higher than 'Number1.maximum=2'. The maximum cannot be less than the minimum.]

  Str1:
    type: string
    maxLength: 2
  Str2:
    type: string
    minLength: 4
  Str3: [ Str1, Str2 ] #Restrictions conflict in type 'Str3': ['Str2.minLength=4' is higher than 'Str1.maxLength=2'. The maxLength cannot be less than the minLength.]

```

Example for min-max facets:
```
types:
  NumberType:
    type: number
    maximum: 2
  OpjType:
    properties:
      prop:   NumberType
    example:
      prop: 4 #'NumberType.maximum=2' i.e. value should not be more than 2
```