### PR TITLE
Exclude "raml-json-validation" and "raml-xml-validation" from browserify build

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
     "date-and-time": "0.3.0",
     "xmldom": "^0.1.22"
   },
+  "browser": {
+    "raml-json-validation": false,
+    "raml-xml-validation": false
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/raml-org/typesystem-ts.git"


### PR DESCRIPTION
This PR fixes browserify build for this package:
```
Error: Cannot find module 'raml-xml-validation' from '/Users/ivang/dev/api-spec-converter/node_modules/raml-typesystem/dist/src'
    at /Users/ivang/dev/api-spec-converter/node_modules/resolve/lib/async.js:46:17
    at process (/Users/ivang/dev/api-spec-converter/node_modules/resolve/lib/async.js:173:43)
    at ondir (/Users/ivang/dev/api-spec-converter/node_modules/resolve/lib/async.js:188:17)
    at load (/Users/ivang/dev/api-spec-converter/node_modules/resolve/lib/async.js:69:43)
    at onex (/Users/ivang/dev/api-spec-converter/node_modules/resolve/lib/async.js:92:31)
    at /Users/ivang/dev/api-spec-converter/node_modules/resolve/lib/async.js:22:47
    at FSReqWrap.oncomplete (fs.js:123:15)
```